### PR TITLE
use HElib's new context I/O

### DIFF
--- a/src/protobuf/protobuf_conversion.cc
+++ b/src/protobuf/protobuf_conversion.cc
@@ -253,9 +253,10 @@ FHEcontext* create_from_message(const Protobuf::FHE_Context &message)
     std::istringstream stream(message.content());
     
     unsigned long m, p, r;
-    readContextBase(stream, m, p, r);
+    vector<long> gens, ords;
+    readContextBase(stream, m, p, r, gens, ords);
     
-    FHEcontext *context = new FHEcontext(m, p, r);
+    FHEcontext *context = new FHEcontext(m, p, r, gens, ords);
     
     stream >> (*context);
 


### PR DESCRIPTION
newer versions of HElib use additional parameters when creating FHEContext objects
