### PR TITLE
Compile justGarble with -fgnu89-inline

### DIFF
--- a/src/justGarble/Makefrag
+++ b/src/justGarble/Makefrag
@@ -5,7 +5,7 @@ SOURCES  := $(wildcard $(SRCDIR)/*.c)
 INCLUDES := $(wildcard $(SRCDIR)/*.h)
 OBJECTS  := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/justGarble/%.o)
 
-JG_CFLAGS= -g -lm -lrt -lpthread -maes -msse4 -lmsgpack -fPIC
+JG_CFLAGS= -g -lm -lrt -lpthread -maes -msse4 -lmsgpack -fgnu89-inline -fPIC
 
 all:    $(OBJDIR)/libjustGarble.so
 $(OBJDIR)/libjustGarble.so: $(OBJECTS)


### PR DESCRIPTION
- fgnu89-inline correctly compiles inlined aes-functions
